### PR TITLE
Add error handling for records that are not found

### DIFF
--- a/lib/vva/base.rb
+++ b/lib/vva/base.rb
@@ -3,6 +3,20 @@ require "savon"
 require "nokogiri"
 
 module VVA
+
+  class HTTPError < StandardError
+    attr_reader :code, :body, :data
+
+    def initialize(code:, body:, data:)
+      super("status_code=#{code}, body=#{body}, data=#{data}")
+      @code = code
+      @body = body
+      @data = data
+    end
+  end
+
+
+
   class Base
     def initialize(wsdl: nil, username: nil, password: nil, log: false,
                    ssl_cert_file: nil, ssl_cert_key_file: nil, ssl_ca_cert: nil)

--- a/lib/vva/services/document_list.rb
+++ b/lib/vva/services/document_list.rb
@@ -8,7 +8,13 @@ module VVA
 
     def get_by_claim_number(claim_number)
       response = request(:get_document_list, "claimNbr": claim_number)
-      response.body[:get_document_list_response][:dcmnt_record].map do |record|
+      document_list = response.body[:get_document_list_response][:dcmnt_record]
+
+      unless document_list
+        fail VVA::HTTPError.new(code: response.http.code, body: response.http.body, data: { claim_number: claim_number })
+      end
+
+      document_list.map do |record|
         OpenStruct.new(
           document_id: record[:fn_dcmnt_id],
           restricted: record[:rstrcd_dcmnt_ind] == "Y" ? true : false,

--- a/spec/fixtures/no_records_found_response.xml
+++ b/spec/fixtures/no_records_found_response.xml
@@ -1,0 +1,8 @@
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <soap:Body>
+    <GetDocumentListResponse xmlns="http://service.bfi.va.gov/">
+      <message>No records found</message>
+      <size>0</size>
+    </GetDocumentListResponse>
+  </soap:Body>
+</soap:Envelope>

--- a/spec/services/document_list_spec.rb
+++ b/spec/services/document_list_spec.rb
@@ -5,21 +5,31 @@ describe VVA::DocumentListWebService do
 
   context "#get_by_claim_number" do
 
+    subject { VVA::DocumentListWebService.new.get_by_claim_number("456456456") }
+
     it "returns correct information" do
       fixture = File.read("spec/fixtures/document_list_response.xml")
       # set up an expectation
       savon.expects(:get_document_list).with(message: { claimNbr: "456456456" }).returns(fixture)
 
-      service = VVA::DocumentListWebService.new
-      response = service.get_by_claim_number("456456456")
-      expect(response).to be_an(Array)
-      doc1 = response[0]
+      subject
+
+      expect(subject).to be_an(Array)
+      doc1 = subject[0]
       expect(doc1.restricted).to eq true
       expect(doc1.document_id).to eq "{780A881E-65E4-4470-8C9D-72F704469682}"
 
-      doc2 = response[1]
+      doc2 = subject[1]
       expect(doc2.restricted).to eq false
       expect(doc2.document_id).to eq "{17D31E31-AC70-432B-8B26-A502A084A590}"
+    end
+
+    it "handles empty list" do
+      fixture = File.read("spec/fixtures/no_records_found_response.xml")
+      # set up an expectation
+      savon.expects(:get_document_list).with(message: { claimNbr: "456456456" }).returns(fixture)
+
+      expect{ subject }.to raise_error(VVA::HTTPError, /No.+records/)
     end
   end
 end


### PR DESCRIPTION
Raise an exception when a claim number is invalid. 

Example:
```
VVA::HTTPError:
       status_code=200, body=<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
         <soap:Body>
           <GetDocumentListResponse xmlns="http://service.bfi.va.gov/">
             <message>No records found</message>
             <size>0</size>
           </GetDocumentListResponse>
         </soap:Body>
       </soap:Envelope>, data={:claim_number=>"456456456"}
```