### PR TITLE
Return empty list instead of error if no documents found for a file n…

### DIFF
--- a/lib/vva/base.rb
+++ b/lib/vva/base.rb
@@ -4,7 +4,10 @@ require "nokogiri"
 
 module VVA
 
-  class HTTPError < StandardError
+  class ClientError < StandardError
+  end
+
+  class HTTPError < ClientError
     attr_reader :code, :body, :data
 
     def initialize(code:, body:, data:)
@@ -15,7 +18,11 @@ module VVA
     end
   end
 
-
+  class SOAPError < ClientError
+    def initialize(msg)
+      super(msg)
+    end
+  end
 
   class Base
     def initialize(wsdl: nil, username: nil, password: nil, log: false,
@@ -64,6 +71,7 @@ module VVA
         ssl_cert_key_file: @ssl_cert_key_file,
         ssl_cert_file: @ssl_cert_file,
         ssl_ca_cert_file: @ssl_ca_cert,
+        ssl_verify_mode: :none,
         pretty_print_xml: true
       )
     end
@@ -72,7 +80,7 @@ module VVA
     def request(method, message)
       client.call(method, message: message)
     rescue Savon::SOAPFault => e
-      raise e
+      raise VVA::SOAPError.new(e)
     end
   end
 end

--- a/lib/vva/services.rb
+++ b/lib/vva/services.rb
@@ -6,7 +6,7 @@ require "vva/services/document_content"
 module VVA
   class Services
     def initialize(wsdl:, username:, password:, log: false,
-                   ssl_cert_file:, ssl_cert_key_file:, ssl_ca_cert:)
+                   ssl_cert_file: nil, ssl_cert_key_file: nil, ssl_ca_cert: nil)
 
       @config = { wsdl: wsdl, username: username, password: password,
                   ssl_cert_file: ssl_cert_file,

--- a/lib/vva/services/document_list.rb
+++ b/lib/vva/services/document_list.rb
@@ -30,7 +30,7 @@ module VVA
           source: record[:fn_dcmnt_source],
           jro: record[:jrsdtn_ro_nbr],
           ssn: record[:ssn_nbr],
-          vva: true
+          downloaded_from: "VVA"
         )
       end
     end

--- a/lib/vva/services/document_list.rb
+++ b/lib/vva/services/document_list.rb
@@ -2,6 +2,12 @@ module VVA
 
   class DocumentListWebService < VVA::Base
 
+    # according to VVA documentation, there are only two mime types: TIFF and PDF
+    MIME_TYPES = {
+      "tiff" => "image/tiff",
+      "pdf" => "application/pdf"
+    }.freeze
+
     def self.service_name
       "document_list"
     end
@@ -10,9 +16,7 @@ module VVA
       response = request(:get_document_list, "claimNbr": claim_number)
       document_list = response.body[:get_document_list_response][:dcmnt_record]
 
-      unless document_list
-        fail VVA::HTTPError.new(code: response.http.code, body: response.http.body, data: { claim_number: claim_number })
-      end
+      return [] if document_list.blank?
 
       document_list.map do |record|
         OpenStruct.new(
@@ -20,10 +24,13 @@ module VVA
           restricted: record[:rstrcd_dcmnt_ind] == "Y" ? true : false,
           type_id: record[:dcmnt_type_lup_id],
           type_description: record[:dcmnt_type_descp_txt],
+          mime_type: MIME_TYPES[record[:dcmnt_format_cd].downcase],
+          received_at: record[:rcvd_dt],
           format: record[:dcmnt_format_cd],
           source: record[:fn_dcmnt_source],
           jro: record[:jrsdtn_ro_nbr],
-          ssn: record[:ssn_nbr]
+          ssn: record[:ssn_nbr],
+          vva: true
         )
       end
     end

--- a/spec/services/document_list_spec.rb
+++ b/spec/services/document_list_spec.rb
@@ -29,7 +29,7 @@ describe VVA::DocumentListWebService do
       # set up an expectation
       savon.expects(:get_document_list).with(message: { claimNbr: "456456456" }).returns(fixture)
 
-      expect{ subject }.to raise_error(VVA::HTTPError, /No.+records/)
+      expect(subject).to eq []
     end
   end
 end

--- a/spec/services/document_list_spec.rb
+++ b/spec/services/document_list_spec.rb
@@ -18,6 +18,7 @@ describe VVA::DocumentListWebService do
       doc1 = subject[0]
       expect(doc1.restricted).to eq true
       expect(doc1.document_id).to eq "{780A881E-65E4-4470-8C9D-72F704469682}"
+      expect(doc1.downloaded_from).to eq "VVA"
 
       doc2 = subject[1]
       expect(doc2.restricted).to eq false


### PR DESCRIPTION
Few changes:
1. Return an empty list instead of an error if no documents are found. We don't want eFolder Express to throw error if there are no documents in VVA.
2. Do not verify server's certificate until @askldjd figures out what's going on with the server's certificate for the VVA Test environment.
3. Add additional fields to the document_list response. 