### PR TITLE
Set SSL cipher suite

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,9 @@
 source 'https://rubygems.org'
 gemspec
 
+gem "httpi",  git: 'https://github.com/faucct/httpi.git', branch: 'feature/open_ssl_ciphers'
+gem "savon",  git: 'https://github.com/esambo/savon.git', branch: 'ciphers'
+
 group :development, :test do
   gem "bundler"
   gem "bundler-audit"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,26 @@
+GIT
+  remote: https://github.com/esambo/savon.git
+  revision: c6e522f1fc15927e4d03e31228f90e1806be4a46
+  branch: ciphers
+  specs:
+    savon (2.11.1)
+      akami (~> 1.2)
+      builder (>= 2.1.2)
+      gyoku (~> 1.2)
+      httpi (~> 2.3)
+      nokogiri (>= 1.4.0)
+      nori (~> 2.4)
+      wasabi (~> 3.4)
+
+GIT
+  remote: https://github.com/faucct/httpi.git
+  revision: af7dbff663e7cec119fb248c12162bca2f893db1
+  branch: feature/open_ssl_ciphers
+  specs:
+    httpi (2.4.2)
+      rack
+      socksify
+
 PATH
   remote: .
   specs:
@@ -20,13 +43,10 @@ GEM
     dotenv (2.2.0)
     gyoku (1.3.1)
       builder (>= 2.1.2)
-    httpi (2.4.2)
-      rack
-      socksify
     method_source (0.8.2)
-    mini_portile2 (2.1.0)
-    nokogiri (1.7.1)
-      mini_portile2 (~> 2.1.0)
+    mini_portile2 (2.2.0)
+    nokogiri (1.8.0)
+      mini_portile2 (~> 2.2.0)
     nori (2.6.0)
     parser (2.4.0.0)
       ast (~> 2.2)
@@ -35,7 +55,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    rack (2.0.1)
+    rack (2.0.3)
     rainbow (2.2.1)
     rake (12.0.0)
     rspec (3.6.0)
@@ -58,14 +78,6 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.8.1)
-    savon (2.11.1)
-      akami (~> 1.2)
-      builder (>= 2.1.2)
-      gyoku (~> 1.2)
-      httpi (~> 2.3)
-      nokogiri (>= 1.4.0)
-      nori (~> 2.4)
-      wasabi (~> 3.4)
     slop (3.6.0)
     socksify (1.7.1)
     thor (0.19.4)
@@ -82,10 +94,12 @@ DEPENDENCIES
   bundler-audit
   connect_vva!
   dotenv
+  httpi!
   pry
   rake
   rspec
   rubocop
+  savon!
 
 BUNDLED WITH
    1.14.4

--- a/lib/vva/base.rb
+++ b/lib/vva/base.rb
@@ -72,6 +72,7 @@ module VVA
         ssl_cert_file: @ssl_cert_file,
         ssl_ca_cert_file: @ssl_ca_cert,
         ssl_verify_mode: :none,
+        ssl_ciphers: "AES128-SHA",
         pretty_print_xml: true
       )
     end


### PR DESCRIPTION
VVA Production Server sends back a DH key that is too small and a newer version of OpenSSL would reject the key:
`HTTPI::SSLError: SSL_connect returned=1 errno=0 state=error: dh key too small`

Two options:
1. Ask VVA to upgrade their OpenSSL in production? 
2. Use forked versions of Savon and HTTPI that let you set SSL cipher and set SSL cipher list to non DH option. I am not a big fan of this option.