### PR TITLE
Savon parses one item list as a hash instead of an array, implement f…

### DIFF
--- a/lib/vva/services/document_list.rb
+++ b/lib/vva/services/document_list.rb
@@ -18,7 +18,7 @@ module VVA
 
       return [] if document_list.blank?
       # Savon parses one item list as a Hash instead of an Array
-      document_list.is_a?(Hash) ? [create_record(document_list)] : document_list.map { |r| create_record(r) }
+      [document_list].flatten.map { |r| create_record(r) }
     end
 
     private

--- a/lib/vva/services/document_list.rb
+++ b/lib/vva/services/document_list.rb
@@ -17,22 +17,26 @@ module VVA
       document_list = response.body[:get_document_list_response][:dcmnt_record]
 
       return [] if document_list.blank?
+      # Savon parses one item list as a Hash instead of an Array
+      document_list.is_a?(Hash) ? [create_record(document_list)] : document_list.map { |r| create_record(r) }
+    end
 
-      document_list.map do |record|
-        OpenStruct.new(
-          document_id: record[:fn_dcmnt_id],
-          restricted: record[:rstrcd_dcmnt_ind] == "Y" ? true : false,
-          type_id: record[:dcmnt_type_lup_id],
-          type_description: record[:dcmnt_type_descp_txt],
-          mime_type: MIME_TYPES[record[:dcmnt_format_cd].downcase],
-          received_at: record[:rcvd_dt].nil? ? nil : Time.strptime(record[:rcvd_dt], "%m/%d/%Y").to_date,
-          format: record[:dcmnt_format_cd],
-          source: record[:fn_dcmnt_source],
-          jro: record[:jrsdtn_ro_nbr],
-          ssn: record[:ssn_nbr],
-          downloaded_from: "VVA"
-        )
-      end
+    private
+
+    def create_record(record)
+      OpenStruct.new(
+        document_id: record[:fn_dcmnt_id],
+        restricted: record[:rstrcd_dcmnt_ind] == "Y" ? true : false,
+        type_id: record[:dcmnt_type_lup_id],
+        type_description: record[:dcmnt_type_descp_txt],
+        mime_type: MIME_TYPES[record[:dcmnt_format_cd].downcase],
+        received_at: record[:rcvd_dt].nil? ? nil : Time.strptime(record[:rcvd_dt], "%m/%d/%Y").to_date,
+        format: record[:dcmnt_format_cd],
+        source: record[:fn_dcmnt_source],
+        jro: record[:jrsdtn_ro_nbr],
+        ssn: record[:ssn_nbr],
+        downloaded_from: "VVA"
+      )
     end
   end
 end

--- a/spec/fixtures/one_record_response.xml
+++ b/spec/fixtures/one_record_response.xml
@@ -1,0 +1,37 @@
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <soap:Body>
+    <GetDocumentListResponse xmlns="http://service.bfi.va.gov/">
+    <dcmntRecord>
+      <dcmntRecordId>44674354459</dcmntRecordId>
+      <authorNm>459_V459VSR1</authorNm>
+      <authorRoNbr>459</authorRoNbr>
+      <batchNm>33407459111354A</batchNm>
+      <categyListTxt>18</categyListTxt>
+      <dcmntFormatCd>PDF</dcmntFormatCd>
+      <dcmntSizeNbr>1</dcmntSizeNbr>
+      <dcmntTypeLupId>457</dcmntTypeLupId>
+      <efoldrId>31978459</efoldrId>
+      <lastUserModifdNm>V459SUP1</lastUserModifdNm>
+      <rcvdDt>10/19/2016</rcvdDt>
+      <readInd>N</readInd>
+      <roLupId>1</roLupId>
+      <rstrcdDcmntInd>Y</rstrcdDcmntInd>
+      <rstrcdReasonLupId>10</rstrcdReasonLupId>
+      <sourceComntTxt>a</sourceComntTxt>
+      <sourceTxt>USER</sourceTxt>
+      <storgDt>10/20/2016</storgDt>
+      <subjctTxt>a</subjctTxt>
+      <trtmntCndtnTxt>a</trtmntCndtnTxt>
+      <dcmntTypeDescpTxt>Unknown PGF</dcmntTypeDescpTxt>
+      <fnDcmntId>{780A881E-65E4-4470-8C9D-72F704469682}</fnDcmntId>
+      <fnDcmntSource>P8</fnDcmntSource>
+      <claimNbr>456456456</claimNbr>
+      <ssnNbr>456456456</ssnNbr>
+      <vetFirstName>DEE</vetFirstName>
+      <vetLastName>TORPEDO</vetLastName>
+      <vetBirthDt>02/01/1965</vetBirthDt>
+      <jrsdtnRoNbr>459</jrsdtnRoNbr>
+    </dcmntRecord>
+    </GetDocumentListResponse>
+  </soap:Body>
+</soap:Envelope>

--- a/spec/services/document_list_spec.rb
+++ b/spec/services/document_list_spec.rb
@@ -34,5 +34,15 @@ describe VVA::DocumentListWebService do
 
       expect(subject).to eq []
     end
+
+    it "handles one record without error" do
+      fixture = File.read("spec/fixtures/one_record_response.xml")
+      # set up an expectation
+      savon.expects(:get_document_list).with(message: { claimNbr: "456456456" }).returns(fixture)
+
+      expect(subject).to be_an(Array)
+      expect(subject.size).to eq 1
+      expect(subject[0].document_id).to eq "{780A881E-65E4-4470-8C9D-72F704469682}"
+    end
   end
 end


### PR DESCRIPTION
…ix around that

connects #11 