### PR TITLE
Anya/13 openssl issues

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,9 +24,9 @@ GEM
       rack
       socksify
     method_source (0.8.2)
-    mini_portile2 (2.1.0)
-    nokogiri (1.7.1)
-      mini_portile2 (~> 2.1.0)
+    mini_portile2 (2.3.0)
+    nokogiri (1.8.1)
+      mini_portile2 (~> 2.3.0)
     nori (2.6.0)
     parser (2.4.0.0)
       ast (~> 2.2)
@@ -35,7 +35,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    rack (2.0.1)
+    rack (2.0.3)
     rainbow (2.2.1)
     rake (12.0.0)
     rspec (3.6.0)

--- a/lib/httpi/net_http/cipher.rb
+++ b/lib/httpi/net_http/cipher.rb
@@ -4,6 +4,10 @@ module HTTPI
 
       private
 
+      # Savon uses the HTTPi library for the network requests but this library
+      # does not support setting SSL ciphers
+      # The following patch redefines net_http setup_ssl_auth to explicitly
+      # deny the DH ciphers in the list of allowed SSL ciphers
       def setup_ssl_auth
         super
         @client.ciphers = ["DEFAULT:!DH"]

--- a/lib/httpi/net_http/cipher.rb
+++ b/lib/httpi/net_http/cipher.rb
@@ -1,0 +1,14 @@
+module HTTPI
+  module NetHTTP
+
+    module Cipher
+
+      private
+
+      def setup_ssl_auth
+        super
+        @client.ciphers = ["DEFAULT:!DH"]
+      end
+    end
+  end
+end

--- a/lib/httpi/net_http/cipher.rb
+++ b/lib/httpi/net_http/cipher.rb
@@ -1,6 +1,5 @@
 module HTTPI
   module NetHTTP
-
     module Cipher
 
       private

--- a/lib/vva/base.rb
+++ b/lib/vva/base.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require "savon"
 require "nokogiri"
+require "httpi/net_http/cipher"
 
 module VVA
 
@@ -35,6 +36,8 @@ module VVA
       @ssl_ca_cert = ssl_ca_cert
       @log = log
     end
+
+    HTTPI::Adapter::NetHTTP.prepend HTTPI::NetHTTP::Cipher
 
     private
 
@@ -72,7 +75,8 @@ module VVA
         ssl_cert_file: @ssl_cert_file,
         ssl_ca_cert_file: @ssl_ca_cert,
         ssl_verify_mode: :none,
-        pretty_print_xml: true
+        pretty_print_xml: true,
+        adapter: :net_http
       )
     end
 


### PR DESCRIPTION
Instead of using unsupported forks of Savon and HTTPI, let's monkeypatch HTTPI's adapter net_http   to reject DH keys. Include this patch only in connect_vva's base class so the rest of Caseflow won't use the patch. 

It works!