### PR TITLE
Handle empty content gracefully

### DIFF
--- a/lib/vva/services/document_content.rb
+++ b/lib/vva/services/document_content.rb
@@ -18,7 +18,7 @@ module VVA
       )
       content = response.body[:get_document_content_response][:content]
       mime_type = response.body[:get_document_content_response][:mime_type]
-      OpenStruct.new(content: Base64.decode64(content), mime_type: mime_type)
+      OpenStruct.new(content: Base64.decode64(content || ""), mime_type: mime_type)
     end
   end
 end

--- a/spec/fixtures/document_with_no_content_response.xml
+++ b/spec/fixtures/document_with_no_content_response.xml
@@ -1,0 +1,1 @@
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body><GetDocumentContentResponse xmlns="http://service.bfi.va.gov/"><content></content><mimeType>application/octet-stream</mimeType></GetDocumentContentResponse></soap:Body></soap:Envelope>

--- a/spec/services/document_content_spec.rb
+++ b/spec/services/document_content_spec.rb
@@ -5,8 +5,7 @@ describe VVA::DocumentContentWebService do
 
   context "#get_by_document_id" do
 
-    it "returns correct information" do
-      fixture = File.read("spec/fixtures/document_content_response.xml")
+    let(:message) do
       # set up an expectation
       message = {
         fnDcmntId: "{DAFE0879-C588-4084-A532-482138F30651}",
@@ -15,18 +14,32 @@ describe VVA::DocumentContentWebService do
         jro: "459",
         userId: "987987987"
       }
-      savon.expects(:get_document_content).with(message: message).returns(fixture)
+    end
 
-      service = VVA::DocumentContentWebService.new
-      response = service.get_by_document_id(
+    let(:service) { VVA::DocumentContentWebService.new }
+    let(:response) do
+      service.get_by_document_id(
         document_id: "{DAFE0879-C588-4084-A532-482138F30651}",
         source: "P8",
         format: "pdf",
         jro: "459",
         ssn: "987987987"
       )
+    end
+
+    it "returns correct information" do
+      fixture = File.read("spec/fixtures/document_content_response.xml")
+      savon.expects(:get_document_content).with(message: message).returns(fixture)
       expect(response).to be_an(OpenStruct)
       expect(response.content).to_not be nil
+      expect(response.mime_type).to eq "application/octet-stream"
+    end
+
+    it "works when content is empty" do
+      fixture = File.read("spec/fixtures/document_with_no_content_response.xml")
+      savon.expects(:get_document_content).with(message: message).returns(fixture)
+      expect(response).to be_an(OpenStruct)
+      expect(response.content).to eq ""
       expect(response.mime_type).to eq "application/octet-stream"
     end
   end


### PR DESCRIPTION
This fixes Sentry alert: https://sentry.ds.va.gov/department-of-veterans-affairs/efolder/issues/584/

Testing:
1. Automated tests added
2. Tested eX to ensure it can somewhat handle empty files. eX silently logs that the file is empty. I created a ticket to investigate what we want to do with the empty files in eX: https://github.com/department-of-veterans-affairs/caseflow-efolder/issues/683