### PR TITLE
Artem/service headers

### DIFF
--- a/lib/vva/base.rb
+++ b/lib/vva/base.rb
@@ -81,6 +81,8 @@ module VVA
     def client
       @client ||= Savon.client(
         wsdl: wsdl,
+        open_timeout: 600,
+        read_timeout: 600,
         soap_header: header,
         namespaces: namespaces,
         log: @log,

--- a/lib/vva/base.rb
+++ b/lib/vva/base.rb
@@ -95,7 +95,8 @@ module VVA
 
     # Proxy to call a method on our web service.
     def request(method, message)
-      client.wsdl.request.headers = { "Host" => domain } if @forward_proxy_url
+      client.wsdl.request.headers = { "service" => method.name.to_s }
+      client.wsdl.request.headers.merge({ "Host" => domain }) if @forward_proxy_url
       client.call(method, message: message)
     rescue Savon::SOAPFault => e
       raise VVA::SOAPError.new(e)

--- a/lib/vva/base.rb
+++ b/lib/vva/base.rb
@@ -95,7 +95,7 @@ module VVA
 
     # Proxy to call a method on our web service.
     def request(method, message)
-      client.wsdl.request.headers = { "service" => method.name.to_s }
+      client.wsdl.request.headers = { "service" => method.to_s }
       client.wsdl.request.headers.merge({ "Host" => domain }) if @forward_proxy_url
       client.call(method, message: message)
     rescue Savon::SOAPFault => e


### PR DESCRIPTION
add service name header for Envoy:
```
GET /VABFI/services/vva?wsdl HTTP/1.1
Service: get_document_list
Accept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3
Accept: */*
User-Agent: Ruby
Host: vbaphid521ldb.vba.va.gov:7002
```

This will allow us to get metrics/routing by headers:
- https://www.envoyproxy.io/docs/envoy/latest/api-v1/route_config/route.html#config-http-conn-man-route-table-route-headers

## To test:
- use this version of the gem send requests through Envoy
- tcpdump requests to see the headers as shown above
- to _really_ test: add header matching in Envoy