### PR TITLE
Artem/envoy paths

### DIFF
--- a/lib/vva/base.rb
+++ b/lib/vva/base.rb
@@ -97,6 +97,7 @@ module VVA
 
     # Proxy to call a method on our web service.
     def request(method, message)
+      http_headers = {}
       http_headers["Host"] = domain if @forward_proxy_url
       client.wsdl.request.headers = http_headers
       client.call(method, message: message)

--- a/lib/vva/base.rb
+++ b/lib/vva/base.rb
@@ -67,7 +67,7 @@ module VVA
 
     def wsdl
       if @forward_proxy_url
-        return @wsdl.gsub(/https:\/\/([a-zA-z0-9\.:\-]+?)\//, @forward_proxy_url+"/")
+        return @wsdl.gsub(/https:\/\/([a-zA-z0-9\.:\-]+?)\//, @forward_proxy_url+"/envoy-prefix-#{method.to_s}")
       end
       @wsdl
     end
@@ -97,7 +97,6 @@ module VVA
 
     # Proxy to call a method on our web service.
     def request(method, message)
-      http_headers = { "Service" => method.to_s }
       http_headers["Host"] = domain if @forward_proxy_url
       client.wsdl.request.headers = http_headers
       client.call(method, message: message)

--- a/lib/vva/base.rb
+++ b/lib/vva/base.rb
@@ -97,9 +97,7 @@ module VVA
 
     # Proxy to call a method on our web service.
     def request(method, message)
-      http_headers = {}
-      http_headers["Host"] = domain if @forward_proxy_url
-      client.wsdl.request.headers = http_headers
+      client.wsdl.request.headers = {"Host" => domain } if @forward_proxy_url
       client.call(method, message: message)
     rescue Savon::SOAPFault => e
       raise VVA::SOAPError.new(e)

--- a/lib/vva/base.rb
+++ b/lib/vva/base.rb
@@ -67,7 +67,7 @@ module VVA
 
     def wsdl
       if @forward_proxy_url
-        return @wsdl.gsub(/https:\/\/([a-zA-z0-9\.:\-]+?)\//, @forward_proxy_url+"/envoy-prefix-#{method.to_s}")
+        return @wsdl.gsub(/https:\/\/([a-zA-z0-9\.:\-]+?)\//, @forward_proxy_url+"/envoy-prefix")
       end
       @wsdl
     end


### PR DESCRIPTION
Adds `envoy-prefix-` path prefix to the proxied requests so that we can extract it for envoy metrics:

connects: https://github.com/department-of-veterans-affairs/appeals-deployment/compare/artem/envoy-header-filter?expand=1