### PR TITLE
Add series_id and version to the document response

### DIFF
--- a/lib/vva/services/document_list.rb
+++ b/lib/vva/services/document_list.rb
@@ -26,6 +26,8 @@ module VVA
     def create_record(record)
       OpenStruct.new(
         document_id: record[:fn_dcmnt_id],
+        series_id: record[:fn_dcmnt_id],
+        version: "1",
         restricted: record[:rstrcd_dcmnt_ind] == "Y" ? true : false,
         type_id: record[:dcmnt_type_lup_id],
         type_description: record[:dcmnt_type_descp_txt],

--- a/spec/services/document_list_spec.rb
+++ b/spec/services/document_list_spec.rb
@@ -18,6 +18,8 @@ describe VVA::DocumentListWebService do
       doc1 = subject[0]
       expect(doc1.restricted).to eq true
       expect(doc1.document_id).to eq "{780A881E-65E4-4470-8C9D-72F704469682}"
+      expect(doc1.series_id).to eq "{780A881E-65E4-4470-8C9D-72F704469682}"
+      expect(doc1.version).to eq "1"
       expect(doc1.downloaded_from).to eq "VVA"
       expect(doc1.received_at).to be_a(Date)
 


### PR DESCRIPTION
For VVA documents, series_id would be the same as document_id and version will always be "1" so we can match VBMS eFolder new API logic. 