### PR TITLE
Catch Savon::HTTPError and rethrow as VVA::SOAPError

### DIFF
--- a/lib/vva/base.rb
+++ b/lib/vva/base.rb
@@ -98,8 +98,10 @@ module VVA
         client.wsdl.request.headers = {"Host" => domain }
       end
       client.call(method, message: message)
-    rescue Savon::SOAPFault, Savon::HTTPError => e
+    rescue Savon::SOAPFault => e
       raise VVA::SOAPError.new(e)
+    rescue Savon::HTTPError => e
+      raise VVA::HTTPError.new(code: e.to_hash[:code], body: e.to_hash[:body], data: e.to_hash[:data])
     end
   end
 end

--- a/lib/vva/base.rb
+++ b/lib/vva/base.rb
@@ -9,13 +9,12 @@ module VVA
   end
 
   class HTTPError < ClientError
-    attr_reader :code, :body, :data
+    attr_reader :code, :body
 
-    def initialize(code:, body:, data:)
-      super("status_code=#{code}, body=#{body}, data=#{data}")
+    def initialize(code:, body:)
+      super("status_code=#{code}, body=#{body}")
       @code = code
       @body = body
-      @data = data
     end
   end
 
@@ -101,7 +100,7 @@ module VVA
     rescue Savon::SOAPFault => e
       raise VVA::SOAPError.new(e)
     rescue Savon::HTTPError => e
-      raise VVA::HTTPError.new(code: e.to_hash[:code], body: e.to_hash[:body], data: e.to_hash[:data])
+      raise VVA::HTTPError.new(code: e.to_hash[:code], body: e.to_hash[:body])
     end
   end
 end

--- a/lib/vva/base.rb
+++ b/lib/vva/base.rb
@@ -98,7 +98,7 @@ module VVA
         client.wsdl.request.headers = {"Host" => domain }
       end
       client.call(method, message: message)
-    rescue Savon::SOAPFault => e
+    rescue Savon::SOAPFault, Savon::HTTPError => e
       raise VVA::SOAPError.new(e)
     end
   end

--- a/spec/services/document_list_spec.rb
+++ b/spec/services/document_list_spec.rb
@@ -2,9 +2,7 @@
 require "spec_helper"
 
 describe VVA::DocumentListWebService do
-
   context "#get_by_claim_number" do
-
     subject { VVA::DocumentListWebService.new.get_by_claim_number("456456456") }
 
     it "returns correct information" do
@@ -45,6 +43,18 @@ describe VVA::DocumentListWebService do
       expect(subject).to be_an(Array)
       expect(subject.size).to eq 1
       expect(subject[0].document_id).to eq "{780A881E-65E4-4470-8C9D-72F704469682}"
+    end
+  end
+
+  context "when VVA returns a 503 response" do
+    before do
+      allow_any_instance_of(Savon::Client).to receive(:call).and_raise(
+        Savon::HTTPError.new(HTTPI::Response.new(503, {}, "upstream connect error or disconnect/reset before headers"))
+      )
+    end
+
+    it "raises a VVA::HTTPError to the calling code" do
+      expect { VVA::DocumentListWebService.new.get_by_claim_number("19891213") }.to raise_error(VVA::HTTPError)
     end
   end
 end


### PR DESCRIPTION
Connects [efolder #916](https://github.com/department-of-veterans-affairs/caseflow-efolder/issues/916).

Catch `Savon::HTTPError`s and rethrow them as `VVA::HTTPError`s so that the consuming projects (efolder in particular) only have to handle `VVA::ClientError`s.